### PR TITLE
Update OCPV documentation URL

### DIFF
--- a/workshop/content/01_welcome.adoc
+++ b/workshop/content/01_welcome.adoc
@@ -63,4 +63,4 @@ The innovation in Kubernetes, serverless, service mesh, Kubernetes Operators, an
 
 == Next steps
 
-If you would like to learn more about OpenShift Virtualization, please visit the https://www.redhat.com/en/technologies/cloud-computing/openshift/virtualization[landing page], review the https://docs.openshift.com/container-platform/latest/virt/about-virt.html[documentation], or view some of our demo videos on https://www.youtube.com/playlist?list=PLaR6Rq6Z4IqeQeTosfoFzTyE_QmWZW6n_[YouTube].
+If you would like to learn more about OpenShift Virtualization, please visit the https://www.redhat.com/en/technologies/cloud-computing/openshift/virtualization[landing page], review the https://docs.openshift.com/container-platform/latest/virt/about_virt/about-virt.html[documentation], or view some of our demo videos on https://www.youtube.com/playlist?list=PLaR6Rq6Z4IqeQeTosfoFzTyE_QmWZW6n_[YouTube].

--- a/workshop/content/04_thanks.adoc
+++ b/workshop/content/04_thanks.adoc
@@ -27,4 +27,4 @@ Depending on your role and interests, you might be interested in completing some
 
 We appreciate your time and effort to gain familiarity with OepnShift Virtualization! If you have questions, please don't hesitate to ask the proctor(s) in the room during your workshop, or reach out to your Red Hat account team at any time.
 
-If you would like to learn more about OpenShift Virtualization, please visit the https://www.redhat.com/en/technologies/cloud-computing/openshift/virtualization[landing page], review the https://docs.openshift.com/container-platform/latest/virt/about-virt.html[documentation], or view some of our demo videos on https://www.youtube.com/playlist?list=PLaR6Rq6Z4IqeQeTosfoFzTyE_QmWZW6n_[YouTube].
+If you would like to learn more about OpenShift Virtualization, please visit the https://www.redhat.com/en/technologies/cloud-computing/openshift/virtualization[landing page], review the https://docs.openshift.com/container-platform/latest/virt/about_virt/about-virt.html[documentation], or view some of our demo videos on https://www.youtube.com/playlist?list=PLaR6Rq6Z4IqeQeTosfoFzTyE_QmWZW6n_[YouTube].


### PR DESCRIPTION
The link to OCPV documentation page has changed and no longer works; this commit updates to the working URL.