### PR TITLE
Parameterize GIT_BRANCH in build-template.yaml

### DIFF
--- a/build-template.yaml
+++ b/build-template.yaml
@@ -19,6 +19,8 @@ parameters:
     value: quay.io/openshifthomeroom/workshop-dashboard:5.0.1
   - name: GIT_REPO
     value: https://github.com/agonzalezrh/roadshow_ocpvirt_instructions
+  - name: GIT_BRANCH
+    value: main
 
 objects:
   - apiVersion: image.openshift.io/v1
@@ -37,7 +39,7 @@ objects:
           name: ${NAME}:latest
       source:
         git:
-          ref: master
+          ref: ${GIT_BRANCH}
           uri: ${GIT_REPO}
         type: Git
       strategy:


### PR DESCRIPTION
add a new parameter for GIT_BRANCH and set the default value to "main"

"master" branch does not exist. Following README.adoc build instructions fails with error: fatal: couldn't find remote ref master