### PR TITLE
Change fedora02 to fedora01 - fix #27

### DIFF
--- a/workshop/content/03_ocpv_basics.adoc
+++ b/workshop/content/03_ocpv_basics.adoc
@@ -161,7 +161,7 @@ As a user with permission to access virtual machines, you can stop, start, resta
 
 . In the left menu, go back to *Virtualization* -> *VirtualMachines*:
 
-. Select the _Virtual Machine_ `fedora02` from the list.
+. Select the _Virtual Machine_ `fedora01` from the list.
 
 . Press the top-right dropdown, *Actions*, to list the available 
 options:


### PR DESCRIPTION
Change name of VM referenced in the optional section _Controlling virtual machine state_.

I did not update the screenshots.

This fixes #27 